### PR TITLE
Remove superfluous real_escape_string's

### DIFF
--- a/add.php
+++ b/add.php
@@ -17,8 +17,8 @@ $mysqli->options(MYSQLI_OPT_CONNECT_TIMEOUT, 5);
 $mysqli->real_connect($config['db_host'],$config['db_user'],$config['db_password'],$config['db_name']); 
 
 // Get all parameter provided by the javascript
-$name = $mysqli->real_escape_string(strip_tags($_POST['name']));
-$firstname = $mysqli->real_escape_string(strip_tags($_POST['firstname']));
+$name = strip_tags($_POST['name']);
+$firstname = strip_tags($_POST['firstname']);
 $tablename = $mysqli->real_escape_string(strip_tags($_POST['tablename']));
 
 $return=false;

--- a/update.php
+++ b/update.php
@@ -19,11 +19,11 @@ $mysqli->real_connect($config['db_host'],$config['db_user'],$config['db_password
                       
 // Get all parameters provided by the javascript
 $colname = $mysqli->real_escape_string(strip_tags($_POST['colname']));
-$id = $mysqli->real_escape_string(strip_tags($_POST['id']));
+$id = strip_tags($_POST['id']);
 $coltype = $mysqli->real_escape_string(strip_tags($_POST['coltype']));
-$value = $mysqli->real_escape_string(strip_tags($_POST['newvalue']));
+$value = strip_tags($_POST['newvalue']);
 $tablename = $mysqli->real_escape_string(strip_tags($_POST['tablename']));
-                                                
+
 // Here, this is a little tips to manage date format before update the table
 if ($coltype == 'date') {
    if ($value === "") 


### PR DESCRIPTION
real_escape_string is not necessary (and introduces artifacts) in values that will be bound to prepared MySQL statements.